### PR TITLE
Remove "example" word in template name

### DIFF
--- a/openshift/templates/laravel-mysql.json
+++ b/openshift/templates/laravel-mysql.json
@@ -2,7 +2,7 @@
   "kind": "Template",
   "apiVersion": "v1",
   "metadata": {
-    "name": "laravel-mysql-example",
+    "name": "laravel-mysql-persistent",
     "annotations": {
       "openshift.io/display-name": "Laravel + MySQL (Persistent)",
       "description": "An example Laravel application with a MySQL database. For more information about using this template, including OpenShift considerations, see https://github.com/luciddreamz/laravel-ex/blob/master/readme.md.",
@@ -12,7 +12,7 @@
   },
   "message": "The following service(s) have been created in your project: ${NAME}, ${DATABASE_SERVICE_NAME}.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/luciddreamz/laravel-ex/blob/master/readme.md.",
   "labels": {
-    "template": "laravel-mysql-example"
+    "template": "laravel-mysql-persistent"
   },
   "objects": [{
     "kind": "Secret",
@@ -150,7 +150,7 @@
               "command": [
                 "./migrate-database.sh"
               ],
-              "containerName": "laravel-mysql-example"
+              "containerName": "laravel-mysql-persistent"
             }
           }
         }
@@ -160,7 +160,7 @@
         "imageChangeParams": {
           "automatic": true,
           "containerNames": [
-            "laravel-mysql-example"
+            "laravel-mysql-persistent"
           ],
           "from": {
             "kind": "ImageStreamTag",
@@ -183,7 +183,7 @@
         },
         "spec": {
           "containers": [{
-            "name": "laravel-mysql-example",
+            "name": "laravel-mysql-persistent",
             "image": "${NAME}",
             "ports": [{
               "containerPort": 8080
@@ -372,7 +372,7 @@
     "displayName": "Name",
     "description": "The name assigned to all of the frontend objects defined in this template.",
     "required": true,
-    "value": "laravel-mysql-example"
+    "value": "laravel-mysql-persistent"
   }, {
     "name": "NAMESPACE",
     "displayName": "Namespace",

--- a/openshift/templates/laravel-postgresql.json
+++ b/openshift/templates/laravel-postgresql.json
@@ -2,7 +2,7 @@
   "kind": "Template",
   "apiVersion": "v1",
   "metadata": {
-    "name": "laravel-pgsql-example",
+    "name": "laravel-pgsql-persistent",
     "annotations": {
       "openshift.io/display-name": "Laravel + PostgreSQL (Persistent)",
       "description": "An example Laravel application with a PostgreSQL database. For more information about using this template, including OpenShift considerations, see https://github.com/luciddreamz/laravel-ex/blob/master/readme.md.",
@@ -12,7 +12,7 @@
   },
   "message": "The following service(s) have been created in your project: ${NAME}, ${DATABASE_SERVICE_NAME}.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/luciddreamz/laravel-ex/blob/master/readme.md.",
   "labels": {
-    "template": "laravel-pgsql-example"
+    "template": "laravel-pgsql-persistent"
   },
   "objects": [{
     "kind": "Secret",
@@ -150,7 +150,7 @@
               "command": [
                 "./migrate-database.sh"
               ],
-              "containerName": "laravel-pgsql-example"
+              "containerName": "laravel-pgsql-persistent"
             }
           }
         }
@@ -160,7 +160,7 @@
         "imageChangeParams": {
           "automatic": true,
           "containerNames": [
-            "laravel-pgsql-example"
+            "laravel-pgsql-persistent"
           ],
           "from": {
             "kind": "ImageStreamTag",
@@ -183,7 +183,7 @@
         },
         "spec": {
           "containers": [{
-            "name": "laravel-pgsql-example",
+            "name": "laravel-pgsql-persistent",
             "image": "${NAME}",
             "ports": [{
               "containerPort": 8080
@@ -367,7 +367,7 @@
     "displayName": "Name",
     "description": "The name assigned to all of the frontend objects defined in this template.",
     "required": true,
-    "value": "laravel-pgsql-example"
+    "value": "laravel-pgsql-persistent"
   }, {
     "name": "NAMESPACE",
     "displayName": "Namespace",

--- a/openshift/templates/laravel-sqlite.json
+++ b/openshift/templates/laravel-sqlite.json
@@ -2,7 +2,7 @@
   "kind": "Template",
   "apiVersion": "v1",
   "metadata": {
-    "name": "laravel-sqlite-example",
+    "name": "laravel-sqlite",
     "annotations": {
       "openshift.io/display-name": "Laravel",
       "description": "An example Laravel application with a SQLite database. For more information about using this template, including OpenShift considerations, see https://github.com/luciddreamz/laravel-ex/blob/master/readme.md.\n\nWARNING: Any data stored will be lost upon pod destruction. Only use this template for testing.",
@@ -12,7 +12,7 @@
   },
   "message": "The following service(s) have been created in your project: ${NAME}.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/luciddreamz/laravel-ex/blob/master/readme.md.",
   "labels": {
-    "template": "laravel-sqlite-example"
+    "template": "laravel-sqlite"
   },
   "objects": [{
     "kind": "Service",
@@ -123,7 +123,7 @@
               "command": [
                 "./migrate-database.sh"
               ],
-              "containerName": "laravel-sqlite-example"
+              "containerName": "laravel-sqlite"
             }
           }
         }
@@ -133,7 +133,7 @@
         "imageChangeParams": {
           "automatic": true,
           "containerNames": [
-            "laravel-sqlite-example"
+            "laravel-sqlite"
           ],
           "from": {
             "kind": "ImageStreamTag",
@@ -156,7 +156,7 @@
         },
         "spec": {
           "containers": [{
-            "name": "laravel-sqlite-example",
+            "name": "laravel-sqlite",
             "image": "${NAME}",
             "ports": [{
               "containerPort": 8080
@@ -214,7 +214,7 @@
     "displayName": "Name",
     "description": "The name assigned to all of the frontend objects defined in this template.",
     "required": true,
-    "value": "laravel-sqlite-example"
+    "value": "laravel-sqlite"
   }, {
     "name": "NAMESPACE",
     "displayName": "Namespace",


### PR DESCRIPTION
The library script uses the name in metadata to determine the name
of the json file. The "example" tag is unnecessary and should be
removed and added "persistent" to keep the generated template json
consistent with others.

Signed-off-by: Vu Dinh <vdinh@redhat.com>